### PR TITLE
New feature - pause tracking keystrokes when mouse cursor moves to a different screen

### DIFF
--- a/KeyNStroke/App.xaml.cs
+++ b/KeyNStroke/App.xaml.cs
@@ -231,6 +231,9 @@ namespace KeyNStroke
                 case "EnableKeystrokeHistory":
                     OnKeystrokeHistorySettingChanged();
                     break;
+                case "PauseCursorDifferentScreen":
+                    OnPauseCursorDifferentScreenChanged();
+                    break;
                 case "EnableAnnotateLine":
                     OnAnnotateLineSettingChanged();
                     break;
@@ -280,7 +283,7 @@ namespace KeyNStroke
             if (KeystrokeHistoryVisible || KeystrokeHistoryWindow != null)
                 return;
             KeystrokeHistoryVisible = true; // Prevent Recursive call
-            KeystrokeHistoryWindow = new KeystrokeDisplay(myKeystrokeConverter, mySettings);
+            KeystrokeHistoryWindow = new KeystrokeDisplay(myKeystrokeConverter, myMouseHook, mySettings);
             KeystrokeHistoryWindow.Show();
         }
 
@@ -291,6 +294,14 @@ namespace KeyNStroke
                 return;
             KeystrokeHistoryWindow.Close();
             KeystrokeHistoryWindow = null;
+        }
+
+        private void OnPauseCursorDifferentScreenChanged()
+        {
+            if (KeystrokeHistoryWindow != null)
+            {
+                KeystrokeHistoryWindow.UpdateDisplayScreenName();
+            }
         }
 
         #endregion

--- a/KeyNStroke/Settings1.xaml
+++ b/KeyNStroke/Settings1.xaml
@@ -129,6 +129,11 @@
                                       IsChecked="{Binding EnableWindowFade}">Hide window when empty</CheckBox>
                             <CheckBox x:Name="cb_periodictopmost"
                                       IsChecked="{Binding PeriodicTopmost}">Put on top periodically</CheckBox>
+                            <CheckBox x:Name="cb_pausecursordifferentscreen_enable"
+                                      IsChecked="{Binding PauseCursorDifferentScreen}"
+                                      ToolTip="Stop tracking keystroke when cursor and keystroke history window are on different screens in a multiple monitors setup">
+                                <TextBlock TextWrapping="Wrap"><Run Text="Pause when cursor and keystroke window are on different screens" /></TextBlock>
+                            </CheckBox>
                         </StackPanel>
                     </StackPanel>
                     <StackPanel Margin="5"

--- a/KeyNStroke/Settings1.xaml.cs
+++ b/KeyNStroke/Settings1.xaml.cs
@@ -111,6 +111,8 @@ namespace KeyNStroke
             settings.PanelSize = settings.PanelSizeDefault;
             settings.WindowLocation = settings.WindowLocationDefault;
             settings.WindowSize = settings.WindowSizeDefault;
+
+            settings.CallPropertyChangedForAllProperties();
         }
 
         private void bn_reset_all_Click(object sender, RoutedEventArgs e)

--- a/KeyNStroke/SettingsStore.cs
+++ b/KeyNStroke/SettingsStore.cs
@@ -203,6 +203,7 @@ namespace KeyNStroke
         [DataMember] public Nullable<bool> enableHistoryTimeout = null;
         [DataMember] public Nullable<bool> enableWindowFade = null;
         [DataMember] public Nullable<bool> enableCursorIndicator = null;
+        [DataMember] public Nullable<bool> pauseCursorDifferentScreen = null;
         [DataMember] public Nullable<double> cursorIndicatorOpacity = null;
         [DataMember] public Nullable<double> cursorIndicatorSize = null;
         [DataMember] public SerializableColor2 cursorIndicatorColor = null;
@@ -414,6 +415,13 @@ namespace KeyNStroke
         {
             get { return Or(i.enableCursorIndicator, EnableCursorIndicatorDefault); }
             set { i.enableCursorIndicator = value; OnSettingChanged("EnableCursorIndicator"); }
+        }
+
+        public bool PauseCursorDifferentScreenDefault = false;
+        public bool PauseCursorDifferentScreen
+        {
+            get { return Or(i.pauseCursorDifferentScreen, PauseCursorDifferentScreenDefault); }
+            set { i.pauseCursorDifferentScreen = value; OnSettingChanged("PauseCursorDifferentScreen"); }
         }
 
         public double CursorIndicatorOpacityDefault = 0.3;
@@ -694,6 +702,7 @@ namespace KeyNStroke
                 PropertyChanged(this, new PropertyChangedEventArgs("EnableHistoryTimeout"));
                 PropertyChanged(this, new PropertyChangedEventArgs("EnableWindowFade"));
                 PropertyChanged(this, new PropertyChangedEventArgs("EnableCursorIndicator"));
+                PropertyChanged(this, new PropertyChangedEventArgs("PauseCursorDifferentScreen"));
                 PropertyChanged(this, new PropertyChangedEventArgs("CursorIndicatorOpacity"));
                 PropertyChanged(this, new PropertyChangedEventArgs("CursorIndicatorSize"));
                 PropertyChanged(this, new PropertyChangedEventArgs("CursorIndicatorColor"));
@@ -827,6 +836,7 @@ HistoryTimeout:                  {HistoryTimeout}
 EnableHistoryTimeout:            {EnableHistoryTimeout}
 EnableWindowFade:                {EnableWindowFade}
 EnableCursorIndicator:           {EnableCursorIndicator}
+PauseCursorDifferentScreen:      {PauseCursorDifferentScreen}
 CursorIndicatorOpacity:          {CursorIndicatorOpacity}
 CursorIndicatorSize:             {CursorIndicatorSize}
 CursorIndicatorColor:            {CursorIndicatorColor}


### PR DESCRIPTION
New feature - pause tracking keystrokes when the mouse cursor moves to a different screen than the keystroke history window. Added a setting to toggle on/off (`Keystroke History > Pause when cursor and keystroke window are on different screens`). Reset the keystroke window screen location when moving the window and also when `Reset position` and `Reset all` buttons are clicked.

Use case:
- RightCtrl + F9 can be used to put the application in standby mode which will stop/pause tracking keystrokes. This option is also useful when only one monitor is used.
- This pull request adds a new option which makes this more seamless on a multiple monitor setup. One main screen is normally used for screen share/recording purposes while another can be used to perform other tasks which we do not want the app to track keystrokes for (e.g. replying text messages, googling, etc.). The user can move the mouse cursor to the other screen to perform actions that they do not want the app to track without toggling the standby mode.